### PR TITLE
Template unbound query logging

### DIFF
--- a/templates/unbound.conf
+++ b/templates/unbound.conf
@@ -53,7 +53,9 @@ server:
     verbosity: 1
     use-syslog: no
     log-time-ascii: yes
+{% if dns.enable_query_logging %}
     log-queries: yes
+{% endif %}
     val-log-level: 2
 
     hide-identity: yes

--- a/vars.yml
+++ b/vars.yml
@@ -53,4 +53,6 @@ firewall:
 #      target: 10.0.0.51
 #      internal_ports: 1234
 #      protocols: udp,tcp
+dns:
+  enable_query_logging: false
 


### PR DESCRIPTION
Currently this PR sets dns.query_logging to true, as that's what we'll be using in our Household Router Contraptions.

However, setting it to false might be a more sensible default due to privacy or -unlikely- performance concerns.

At any rate, this can be changed ad-hoc via "unbound-control set_option log-queries: (yes|no)".

What do you think?
