### PR TITLE
Make DNSSEC (strict) validation optional

### DIFF
--- a/templates/unbound.conf
+++ b/templates/unbound.conf
@@ -60,8 +60,13 @@ server:
     hide-identity: yes
     hide-version: yes
 
+{% if dns.enable_dnssec_validation %}
     auto-trust-anchor-file: "/var/unbound/db/root.key"
     val-log-level: 2
+{% if dns.permissive_dnssec_validation %}
+    val-permissive-mode: yes
+{% endif %}
+{% endif %}
 
 remote-control:
      control-enable: yes

--- a/vars.yml
+++ b/vars.yml
@@ -55,4 +55,6 @@ firewall:
 #      protocols: udp,tcp
 dns:
   enable_query_logging: false
+  enable_dnssec_validation: true
+  permissive_dnssec_validation: false
 


### PR DESCRIPTION
The validator module's logging level is set to two (log bogus DNS label
and reason of failure) under the enthusiastic assumption that DNSSEC
validation errors will be something between scarce and bearable.

When not, the permissive_validation option will make unbound pass
replies to clients when validation fails for _any_ domain.
