### PR TITLE
Rejig how we handle local variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+local-vars.yml

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Once you have installed [OpenBSD][openbsd] you are ready to install OpenHRC.
   We know, piping things from the internet to the shell directly is not a good
   idea... You're more than welcome to check the contents of the script, which
   basically just installs a few basic packages and clones this repository.
-* Edit vars.yml to your liking
+* View vars.yml, override variables in local-vars.yml to your liking
 * Run ./configure.sh
 * Reboot and have fun!
 
@@ -112,6 +112,12 @@ port_forwardings:
 **Q:** No IPv6 support, are you serious?
 
 **A:** It's coming up in the next release, hold tight!
+
+**Q:** How can I override the variables used in the playbooks?
+
+**A:** You can provide your own variables in the local-vars.yml file.
+The user_* list variables are empty by default. Override those you need by adding them to local variables file.
+In order to override variables stored in dictionaries (like the firewall or dns sections, for example), you can override individual keys that will be merged with the remaining default keys.
 
 **Q:** My favorite site/TLD have screwed their DNSSEC. Is there anything I can do?
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,3 @@
 [defaults]
 jinja2_extensions=jinja2.ext.do
+hash_behaviour=merge

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,5 +12,7 @@ pkg_add -z git
 echo "Downloading OHRC..."
 git clone https://github.com/ioc32/openhrc
 
-echo "Bootstrap done, edit vars.yml and run configure.sh"
+touch openhrc/local-vars.yml
+
+echo "Bootstrap done, set local variables in local-vars.yml and run configure.sh"
 

--- a/configure.sh
+++ b/configure.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 echo "Running stage1..."
-ansible-playbook stage1.yml
+ansible-playbook -e @local-vars.yml stage1.yml
 
 echo "Running stage2..."
-ansible-playbook stage2.yml
+ansible-playbook -e @local-vars.yml stage2.yml
 
 echo "System configured! It's time to reboot now. Have fun!"


### PR DESCRIPTION
Ansible will give the highest priority to those variables provided at
the CLI via the -e switch.

This switch accepts YAML or JSON formatted files via '-e @FILE'. This
file can be empty.

We can drop an empty local-vars.yml after cloning the repo in
bootstrap.sh, which will be ignored via .gitignore.

The key to proper dict overrides is to set hash_behaviour to 'merge' instead of 'replace'.
This is more convenient for the user, since individual dictionary keys can be overriden
No need to copy the whole dictionary.
