### PR TITLE
Change mirror transport and target

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,7 +2,7 @@
 
 RELEASE=$(sysctl kern.version | grep -q current && echo snapshots || echo $(uname -r))
 ARCH=$(uname -p)
-export PKG_PATH=ftp://ftp.eu.openbsd.org/pub/OpenBSD/$RELEASE/packages/$ARCH/
+export PKG_PATH=https://cdn.openbsd.org/pub/OpenBSD/$RELEASE/packages/$ARCH/
 
 echo "Using $PKG_PATH"
 pkg_add -z ansible

--- a/templates/installurl
+++ b/templates/installurl
@@ -1,1 +1,1 @@
-{{ mirror }}/pub/OpenBSD/
+https://{{ mirror }}/pub/OpenBSD/

--- a/vars.yml
+++ b/vars.yml
@@ -1,5 +1,5 @@
 ---
-mirror: ftp://ftp.eu.openbsd.org
+mirror: cdn.openbsd.org
 hostname: openhrc
 interfaces:
   wan:


### PR DESCRIPTION
Up until now we were using FTP and a hardcoded EU DNS name for this.

Let's not assume all OpenHRC users are in the EU :clown_face: and
move to a CDN-based name.

I know, we're selling out to Fastly, but I am getting old and I am
fresh out of fucks to give today!

As per `pkg_add(1)` and `installurl(5)`, we should have no issues
moving to HTTPS.