### PR TITLE
Enable unbound's RPZ support for host blocking

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -41,11 +41,11 @@
           enabled=yes
         with_items: "{{ base_daemons }}"
 
-      - name: enable user services
+      - name: setup user services
         service:
           name={{item.name}}
           args="{{item.args|default('')}}"
-          enabled={{item.enabled}}
+          enabled={{ "yes" if item.enable else "no" }}
         with_items: "{{ user_daemons }}"
 
       - name: template /etc files
@@ -81,10 +81,27 @@
           group=wheel
           mode=0644
 
-      - name: create crypto material for unbound-control
-        command: unbound-control-setup -d /var/unbound/etc/
-        args:
-          creates: /var/unbound/etc/unbound_server.key
+      - block:
+          - name: template RPZ zone update script
+            template:
+              backup=yes
+              src=templates/update-rpz.sh
+              dest=/usr/local/sbin
+              owner=root
+              mode=0770
+
+          - name: Run RPZ zone update script once at startup
+            cron:
+              name="daily RPZ zone update script"
+              job=/usr/local/sbin/update-rpz.sh
+              special_time=reboot
+
+          - name: Run RPZ zone update script daily
+            cron:
+              name="daily RPZ zone update script"
+              job=/usr/local/sbin/update-rpz.sh
+              special_time=daily
+        when: dns.rpz.enable
 
       - name: install upnp service
         openbsd_pkg:
@@ -111,7 +128,7 @@
         openbsd_pkg:
           name=inadyn
           state=present
-        when: ddns.enabled
+        when: ddns.enable
 
       - name: template ddns configuration file
         template:
@@ -120,7 +137,7 @@
           owner=root
           mode=0644
           src=templates/inadyn.conf
-        when: ddns.enabled
+        when: ddns.enable
 
       - name: install user packages
         openbsd_pkg:
@@ -132,4 +149,4 @@
         service:
           name=inadyn
           args=""
-          enabled={{ "yes" if ddns.enabled else "no" }}
+          enabled={{ "yes" if ddns.enable else "no" }}

--- a/templates/dhcpd.conf
+++ b/templates/dhcpd.conf
@@ -5,7 +5,7 @@ authoritative;
 
 option domain-name-servers {{ ip | ipaddr('address') }};
 option domain-name "{{ dns.authoritative.zone }}";
-{% if ntp.enabled %}
+{% if ntp.enable %}
 option ntp-servers {{ ip | ipaddr('address') }};
 {% endif %}
 

--- a/templates/ntpd.conf
+++ b/templates/ntpd.conf
@@ -1,6 +1,6 @@
 # templated by ansible
 
-{% if ntp.enabled %}
+{% if ntp.enable %}
 {% set ip = interfaces.lan.ip4 | ipv4('host/prefix') %}
 listen on {{ ip | ipaddr('address') }}
 {% endif %}

--- a/templates/unbound.conf
+++ b/templates/unbound.conf
@@ -2,6 +2,10 @@
 
 {% set ip = interfaces.lan.ip4 | ipv4('host/prefix') %}
 server:
+{% if dns.rpz.enable %}
+    module-config: "respip validator iterator"
+
+{% endif %}
     access-control: 0.0.0.0/0 refuse
     access-control: 127.0.0.0/8 allow
     access-control: ::0/0 refuse
@@ -35,7 +39,7 @@ server:
 {% endif %}
 
     # Inline RRs for {{ dns.authoritative.zone }}
-    local-data: '{{ hostname }}.{{ dns.authoritative.zone }}. IN A {{ interfaces.lan.ip4 }}'
+    local-data: '{{ hostname }}.{{ dns.authoritative.zone }}. IN A {{ interfaces.lan.ip4 | ipaddr('address') }}'
 {% for entry in dhcp.static_mappings %}
     local-data: '{{ entry.host }}.{{ dns.authoritative.zone }}. IN A {{ entry.ip }}'
 {% endfor %}
@@ -47,6 +51,13 @@ server:
     local-data: '{{ record }}'
 {% endfor %}
 
+{% if dns.rpz.enable %}
+    rpz:
+        name: rpz.home.lan
+        zonefile: "/var/unbound/rpz.home.lan.zone"
+        rpz-log: yes
+
+{% endif %}
 remote-control:
      control-enable: yes
      control-interface: /var/run/unbound.sock

--- a/templates/update-rpz.sh
+++ b/templates/update-rpz.sh
@@ -1,0 +1,26 @@
+#!/bin/ksh
+
+set -e
+
+RPZ_ZONE=rpz.{{ dns.authoritative.zone }}
+DEST_ZONE=/var/unbound/${RPZ_ZONE}.zone
+TMP_ZONE=`mktemp -t ${RPZ_ZONE}-zone.XXXXXXXXXX`
+TMP_HOSTS=`mktemp -t ${RPZ_ZONE}-hosts.XXXXXXXXXX`
+
+URLS[0]=https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
+URLS[1]=https://gitlab.com/curben/urlhaus-filter/raw/master/urlhaus-filter-hosts.txt
+
+for URL in ${URLS[@]}; do ftp -MV -o - $URL >> $TMP_HOSTS; done
+
+sort -u $TMP_HOSTS | \
+awk -v RPZ_ZONE="${RPZ_ZONE}." \
+    'BEGIN {printf "$ORIGIN %s\n",RPZ_ZONE;
+            printf "%s IN SOA ns1.%s admin.%s 0000000001 86400 7200 604800 300\n",RPZ_ZONE,RPZ_ZONE,RPZ_ZONE}
+     /^0\.0\.0\.0.+[a-z]$/ {printf "%s CNAME .\n",$2}' > $TMP_ZONE
+
+nsd-checkzone $RPZ_ZONE $TMP_ZONE >/dev/null
+mv -f $TMP_ZONE $DEST_ZONE
+chown _unbound:_unbound $DEST_ZONE
+unbound-control -q reload
+
+rm -f $TMP_HOSTS $TMP_ZONE

--- a/vars.yml
+++ b/vars.yml
@@ -37,8 +37,10 @@ dns:
   # Sample records
   #   - router IN A   10.0.0.1
   #   - foo IN A   10.0.0.2
+  rpz:
+    enable: false
 ntp:
-  enabled: true
+  enable: true
   pools:
     servers:
       - 0.openbsd.pool.ntp.org
@@ -53,9 +55,9 @@ base_daemons:
 user_daemons: []
 # Sample user daemon
 #  - name: sndiod
-#    enabled: no
+#    enable: no
 #  - name: sensorsd
-#    enabled: yes
+#    enable: yes
 sysctls:
   net.inet.ip.forwarding: 1
   net.inet6.ip6.forwarding: 1
@@ -75,10 +77,9 @@ firewall:
 #      internal_ports: 1234
 #      protocols: udp,tcp
 ddns:
-    enabled: false
+    enable: false
     update_period_sec: 600
     username: test
     password: test
     dyndns_system: default@freedns.afraid.org
     alias: test.mooo.com
-


### PR DESCRIPTION
Using RPZ allows us to mangle DNS responses so the hosts
we wish to filter return NXDOMAIN responses. This should
even prevent connection attempts.

It'll log:
```
unbound: [41788:0] info: RPZ applied vortex.data.microsoft.com. nxdomain 10.0.0.5@51516 vortex.data.microsoft.com. A IN
unbound: [41788:0] info: RPZ applied vortex.data.microsoft.com. nxdomain 10.0.0.5@51516 vortex.data.microsoft.com. AAAA IN
```

It's this kind of visibility, rather than the additional
capabilities of RPZ over returning `0.0.0.0/127.0.0.1` as
DNS responses, or rejecting TCP connection, what makes me lean
towards using RPZ.

It does add some complexity over the aforementioned alternatives
but in my view it's pretty affordable.

Ship it disabled by default.

While there, indulge myself in a drive-by commit to replace
`_enabled` with `_enable`, which is shorter and we also use
extensively in the code. Remove unneeded unbound tasks too,
as we moved to unix sockets instead.

See [openhrc/issues/17](https://github.com/ioc32/openhrc/issues/17) for
details.